### PR TITLE
fix: rename package from 'homepage' to 'panelio'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "homepage",
+  "name": "panelio",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Renomme le champ `name` dans `package.json` pour refléter l'identité du projet.